### PR TITLE
Split DISCONNECT into INITIAL and DISCONNECT states.

### DIFF
--- a/include/monetra_api.h
+++ b/include/monetra_api.h
@@ -186,7 +186,8 @@ enum LM_conn_status {
 	LM_CONN_STATUS_CONNECTED     = 2, /*!< Actively connected */
 	LM_CONN_STATUS_DISCONNECTING = 3, /*!< In the process of disconnecting */
 	LM_CONN_STATUS_IDLE_TIMEOUT  = 4, /*!< In the process of disconnecting due to idle timeout */
-	LM_CONN_STATUS_DISCONNECTED  = 5  /*!< Connection failed or not yet attempted */
+	LM_CONN_STATUS_DISCONNECTED  = 5, /*!< Connection failed */
+	LM_CONN_STATUS_INITIAL       = 6, /*!< Connection not yet attempted */
 };
 typedef enum LM_conn_status LM_conn_status_t;
 

--- a/src/monetra_conn.c
+++ b/src/monetra_conn.c
@@ -27,7 +27,7 @@ LM_conn_t * LM_SPEC LM_conn_init(M_event_t *event, LM_event_callback_t event_cal
 	conn                 = M_malloc_zero(sizeof(*conn));
 	conn->event          = event;
 	conn->event_callback = event_callback;
-	conn->status         = LM_CONN_STATUS_DISCONNECTED;
+	conn->status         = LM_CONN_STATUS_INITIAL;
 
 	conn->lock           = M_thread_mutex_create(M_THREAD_MUTEXATTR_NONE);
 	conn->rnd            = M_rand_create(0);


### PR DESCRIPTION
In order to provide better M_Monitor() functionality.

modified:   include/monetra_api.h
modified:   src/monetra_conn.c
modified:   src/monetra_legacy.c